### PR TITLE
Feat/extend errors

### DIFF
--- a/src/errors/authError.ts
+++ b/src/errors/authError.ts
@@ -1,0 +1,8 @@
+import { ErrorCode, VanellusError } from '.'
+
+export class BackendError extends VanellusError {
+  constructor() {
+    super(ErrorCode.KeysMissing)
+    this.name = "AuthError";
+  }
+}

--- a/src/errors/authError.ts
+++ b/src/errors/authError.ts
@@ -1,6 +1,6 @@
 import { ErrorCode, VanellusError } from '.'
 
-export class BackendError extends VanellusError {
+export class AuthError extends VanellusError {
   constructor() {
     super(ErrorCode.KeysMissing)
     this.name = "AuthError";

--- a/src/errors/backendError.ts
+++ b/src/errors/backendError.ts
@@ -9,6 +9,7 @@ export class BackendError extends VanellusError {
 
   constructor(data: {error: string, data?: string}) {
     super(ErrorCode.BackendError)
+    this.name = "BackendError";
     this.data = data
   }
 }

--- a/src/errors/unexpectedError.ts
+++ b/src/errors/unexpectedError.ts
@@ -1,6 +1,6 @@
 import { Optional } from '../helpers/optional'
 import { ErrorCode } from './'
-import { getErrorDescriptionForCode } from './vanellusError'
+import { getErrorMessageForCode } from './vanellusError'
 
 
 export class UnexpectedError extends Error {
@@ -8,7 +8,8 @@ export class UnexpectedError extends Error {
   public readonly baseError: Optional<unknown>
 
   constructor(code: ErrorCode, baseError: Optional<unknown> = null) {
-    super(getErrorDescriptionForCode(code))
+    super(getErrorMessageForCode(code))
+    this.name = "UnexpectedError";
     this.code = code
     this.baseError = baseError
   }

--- a/src/errors/vanellusError.ts
+++ b/src/errors/vanellusError.ts
@@ -2,7 +2,7 @@ import { ErrorCode } from '.';
 
 
 
-export function getErrorDescriptionForCode(code: ErrorCode): string {
+export function getErrorMessageForCode(code: ErrorCode): string {
   switch(code) {
     case ErrorCode.KeysMissing:
       return "Keys are missing"
@@ -16,17 +16,13 @@ export function getErrorDescriptionForCode(code: ErrorCode): string {
   return "";
 }
 
-export class VanellusError {
+export class VanellusError extends Error {
   public readonly code: ErrorCode;
-  public readonly description: string;
 
-  constructor(code: ErrorCode, description?: string) {
+  constructor(code: ErrorCode, message?: string) {
+    super(message ? message : getErrorMessageForCode(code));
+    this.name = "VanellusError";
     this.code = code;
-
-    if (!description) {
-      description = getErrorDescriptionForCode(code)
-    }
-    this.description = description;
   }
 }
 

--- a/src/interfaces/provider.ts
+++ b/src/interfaces/provider.ts
@@ -38,7 +38,7 @@ export interface ProviderPublicKeys {
 }
 
 export interface ProviderInput {
-    id?: string
+    
     name: string
     street: string
     city: string
@@ -50,10 +50,10 @@ export interface ProviderInput {
 }
 
 export interface ProviderData extends ProviderInput {
+    id: string
     publicKeys: ProviderPublicKeys
     submittedAt?: string
     version?: string
-    id?: string
 }
 
 

--- a/src/interfaces/provider.ts
+++ b/src/interfaces/provider.ts
@@ -38,7 +38,7 @@ export interface ProviderPublicKeys {
 }
 
 export interface ProviderInput {
-    
+    id?: string
     name: string
     street: string
     city: string
@@ -50,10 +50,10 @@ export interface ProviderInput {
 }
 
 export interface ProviderData extends ProviderInput {
-    id: string
     publicKeys: ProviderPublicKeys
     submittedAt?: string
     version?: string
+    id?: string
 }
 
 


### PR DESCRIPTION
This PR extends the new error-handling to:

 - generally extend the base-Error-class
 - align with node's error.message property
 - set constructor.name to have more expressive error-messages
 - adds AuthError-class to be used when authentication is missing to be able to handle redirect to the login-page in the UI globally