### PR TITLE
pin NodeJS version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+nodejs lts-gallium

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,9 @@
                 "ts-node": "^10.4.0",
                 "typescript": "^4.5.3"
             },
+            "engines": {
+                "node": ">=16.0.0"
+            },
             "peerDependencies": {
                 "buffer": "^6"
             }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     },
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
+    "engines": {
+        "node": ">=16.0.0"
+    },
     "scripts": {
         "build": "tsc --build",
         "test": "mocha --require ts-node/register --extension ts src/**/*.spec.ts",


### PR DESCRIPTION
I've had issues with locally installed Node v14 so I want to pin it and enforce using >=16 as you guys all seem to use it.

I personally use asdf for managing my tool versions because it also supports go, pnpm, etc. so I added both.

- add tool-versions
- add nvmrc
- add `engines` property to enforce node version